### PR TITLE
Update technical-limitations-criteria.md

### DIFF
--- a/wiki/ranking/criteria/technical-limitations-criteria.md
+++ b/wiki/ranking/criteria/technical-limitations-criteria.md
@@ -10,7 +10,7 @@ Until further notice the new v4 map format will be unrankable. This will stay in
 
 - Maps must not break **350 BPM sustained**
 - Maps must not break **13.5⭐difficulty**
-- Maps must not break **11.5⭐difficulty** without a QAT upvote on all ranked difficulties and receive 2/3 approval by RT and QAT
+- Maps must not break **12⭐difficulty** without a QAT upvote on all ranked difficulties and receive 2/3 approval by RT and QAT
 - Current limit for map length is **10 minutes**
 - Maps must not contain chains.
 


### PR DESCRIPTION
updates the “map must not break ~⭐️ without having QAT upvote on all diffs”